### PR TITLE
Show all users in both table and p-tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
 <body>
   <div id = mainDiv class="container">
     <div id= viewPersonWithData></div>
-    <div id = viewAllPersonsWithDataData></div>
+    <div id = viewAllPersonsWithData></div>
     <div id="addPersonSimple">
       <h3>Add a person</h3>
       <label for="inputFirstName">First name:</label>

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,9 @@
         <div id=viewPersonWithData></div>
       </div>
       <div class="col">
+        <div id=viewAllPersonsWithData></div>
+      </div>
+      <div class="col">
         <div id="addPersonSimple">
           <h3>Add a person</h3>
           <label for="inputFirstName">First name:</label>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id = mainDiv class="container">
     <div id= viewPersonWithData></div>
+    <div id = viewAllPersonsWithDataData></div>
     <div id="addPersonSimple">
       <h3>Add a person</h3>
       <label for="inputFirstName">First name:</label>

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,10 @@ document.addEventListener("DOMContentLoaded", function () {
     document.getElementById("viewPersonWithDataButtonTAG").addEventListener('click', function (event) {
         event.preventDefault();
         singleuser();
-        /*---------- End Get Person By Name ----------*/
+    });
+    document.getElementById("viewAllPersonsWithDataButtonTAG").addEventListener('click', function (event) {
+        event.preventDefault();
+        allUsers();
     });
 });
 
@@ -61,7 +64,7 @@ function singleuser() {
         fetch(urlName)
             .then(handleHttpErrors)
             .then(fetchedData => {
-                writeToPTagPrPerson(fetchedData);
+                writeToPTagPrPerson(fetchedData, 'viewPersonWithDataPTAG');
             })
             .catch(err => {
                 if (err.status) {
@@ -72,7 +75,7 @@ function singleuser() {
     }
 }
 
-function writeToPTagPrPerson(jsondata) {
+function writeToPTagPrPerson(jsondata, tagToWrite) {
     let person = jsondata[0];
     let hobbies = '';
     person['hobbies'].forEach(element => {
@@ -83,7 +86,7 @@ function writeToPTagPrPerson(jsondata) {
         phones = phones + '<br>' + element.description + ': ' + element.number;
     });
 
-    document.getElementById('viewPersonWithDataPTAG').innerHTML =
+    document.getElementById(tagToWrite).innerHTML =
         "<br>Firstname: " + person['firstName'] + ' ' + person['lastName']
         + "<br>e-mail: " + person['email']
         + "<br>Address: " + person['address']['street'] + ', '
@@ -155,42 +158,27 @@ function createPersonOptions() {
 /*---------------------------------------------*/
 
 function fillViewAllPersonsWithDataDiv() {
-    emptyDiv('viewAllPersonsWithDataData');
+    emptyDiv('viewAllPersonsWithData');
     let ptag = document.createElement('p');
     ptag.setAttribute('id', 'viewAllPersonsWithDataPTAG');
 
     let buttontag = document.createElement('button');
     buttontag.innerHTML = 'Get All Users';
-    buttontag.setAttribute('id', 'viewAllPersonsWithDataTAG');
+    buttontag.setAttribute('id', 'viewAllPersonsWithDataButtonTAG');
 
-    let div = document.getElementById('viewAllPersonsWithDataData');
+    let div = document.getElementById('viewAllPersonsWithData');
     div.appendChild(buttontag);
     div.appendChild(ptag);
 }
 
 function allUsers() {
-    let urlAll = url + '/allpersons';
+    let urlAll = url + 'allpersons';
     fetch(urlAll)
         .then(handleHttpErrors)
         .then(jsondata => {
-            let person = jsondata[0];
-            let hobbies = '';
-            person['hobbies'].forEach(element => {
-                hobbies = hobbies + '<br>' + element.name + ' - ' + element.description;
+            jsondata.forEach(element => {
+                writeToPTagPrPerson(element, 'viewAllPersonsWithDataPTAG');
             });
-            let phones = '';
-            person['phones'].forEach(element => {
-                phones = phones + '<br>' + element.description + ': ' + element.number;
-            });
-
-            document.getElementById('viewPersonWithDataPTAG').innerHTML =
-                "<br>Firstname: " + person['firstName'] + ' ' + person['lastName']
-                + "<br>e-mail: " + person['email']
-                + "<br>Address: " + person['address']['street'] + ', '
-                + person['address']['additionalInfo'] + ', ' + person['address']['cityInfo']['zipCode']
-                + ' ' + person['address']['cityInfo']['city']
-                + "<br>Hobbies: " + hobbies
-                + "<br>Phones: " + phones;
         })
         .catch(err => {
             if (err.status) {

--- a/src/index.js
+++ b/src/index.js
@@ -170,9 +170,13 @@ function fillViewAllPersonsWithDataDiv() {
     buttontag.innerHTML = 'Get All Users';
     buttontag.setAttribute('id', 'viewAllPersonsWithDataButtonTAG');
 
+    let tabletag = document.createElement('table');
+    tabletag.setAttribute('id', 'viewAllPersonsWithDataTableTAG');
+
     let div = document.getElementById('viewAllPersonsWithData');
     div.appendChild(buttontag);
     div.appendChild(ptag);
+    div.appendChild(tabletag);
 }
 
 function allUsersToPtag() {

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ function createPersonOptions() {
 /*----------- Begin Get All Persons -----------*/
 /*---------------------------------------------*/
 
-// TO DELETE WHEN MERGE WITH MASTER - IS CPOPY OF EXISTING METHOD ON MASTER BRANCH
+// TO DELETE WHEN MERGE WITH MASTER - IS COPY OF EXISTING METHOD ON MASTER BRANCH
 function emptyViewPersonWithDataDiv() {
     let div = document.getElementById("viewPersonWithData");
     div.innerHTML = "";

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,20 @@ function singleuser() {
         let urlName = url + 'person/' + username;
         fetch(urlName)
             .then(handleHttpErrors)
-            .then(jsondata => {
-                let person = jsondata[0];
+            .then(fetchedData => {
+                writeToPTagPrPerson(fetchedData);
+            })
+            .catch(err => {
+                if (err.status) {
+                    err.fullError.then(e => console.log(e.detail))
+                }
+                else { console.log("Network error"); }
+            });
+    }
+}
+
+function writeToPTagPrPerson(jsondata){
+    let person = jsondata[0];
                 let hobbies = '';
                 person['hobbies'].forEach(element => {
                     hobbies = hobbies + '<br>' + element.name + ' - ' + element.description;
@@ -79,14 +91,6 @@ function singleuser() {
                   + ' ' + person['address']['cityInfo']['city']
                   + "<br>Hobbies: " + hobbies
                   + "<br>Phones: " + phones;
-            })
-            .catch(err => {
-                if (err.status) {
-                    err.fullError.then(e => console.log(e.detail))
-                }
-                else { console.log("Network error"); }
-            });
-    }
 }
 
 /*---------------------------------------------*/

--- a/src/index.js
+++ b/src/index.js
@@ -72,25 +72,25 @@ function singleuser() {
     }
 }
 
-function writeToPTagPrPerson(jsondata){
+function writeToPTagPrPerson(jsondata) {
     let person = jsondata[0];
-                let hobbies = '';
-                person['hobbies'].forEach(element => {
-                    hobbies = hobbies + '<br>' + element.name + ' - ' + element.description;
-                });
-                let phones = '';
-                person['phones'].forEach(element => {
-                    phones = phones + '<br>' + element.description + ': ' + element.number;
-                });
+    let hobbies = '';
+    person['hobbies'].forEach(element => {
+        hobbies = hobbies + '<br>' + element.name + ' - ' + element.description;
+    });
+    let phones = '';
+    person['phones'].forEach(element => {
+        phones = phones + '<br>' + element.description + ': ' + element.number;
+    });
 
-                document.getElementById('viewPersonWithDataPTAG').innerHTML =
-                   "<br>Firstname: " + person['firstName'] + ' '+ person['lastName']
-                  + "<br>e-mail: " + person['email']
-                  + "<br>Address: " + person['address']['street'] + ', '
-                  + person['address']['additionalInfo'] + ', ' + person['address']['cityInfo']['zipCode'] 
-                  + ' ' + person['address']['cityInfo']['city']
-                  + "<br>Hobbies: " + hobbies
-                  + "<br>Phones: " + phones;
+    document.getElementById('viewPersonWithDataPTAG').innerHTML =
+        "<br>Firstname: " + person['firstName'] + ' ' + person['lastName']
+        + "<br>e-mail: " + person['email']
+        + "<br>Address: " + person['address']['street'] + ', '
+        + person['address']['additionalInfo'] + ', ' + person['address']['cityInfo']['zipCode']
+        + ' ' + person['address']['cityInfo']['city']
+        + "<br>Hobbies: " + hobbies
+        + "<br>Phones: " + phones;
 }
 
 /*---------------------------------------------*/

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ document.addEventListener("DOMContentLoaded", function () {
     /*---------- Begin Get Person By Name ---------*/
     /*----- Should be moved to NavBar function ----*/
     fillViewPersonWithDataDiv();
+    fillViewAllPersonsWithDataDiv()
     document.getElementById("viewPersonWithDataButtonTAG").addEventListener('click', function (event) {
         event.preventDefault();
         singleuser();
@@ -25,7 +26,7 @@ function handleHttpErrors(res) {
 /*---------------------------------------------*/
 
 function fillViewPersonWithDataDiv() {
-    
+    emptyDiv('viewPersonWithData');
     let ptag = document.createElement('p');
     ptag.setAttribute('id', 'viewPersonWithDataPTAG');
 
@@ -38,17 +39,15 @@ function fillViewPersonWithDataDiv() {
     buttontag.innerHTML = 'Get User';
     buttontag.setAttribute('id', 'viewPersonWithDataButtonTAG');
 
-    let div = document.getElementById("viewPersonWithData");
-    div.innerHTML = "";
+    let div = document.getElementById('viewPersonWithData');
     div.appendChild(inputtag);
     div.appendChild(buttontag);
     div.appendChild(ptag);
 }
 
-/*---------- Not used yet ---------*/
 /*---- To clear the div of data ---*/
-function emptyViewPersonWithDataDiv() {
-    let div = document.getElementById("viewPersonWithData");
+function emptyDiv(divID) {
+    let div = document.getElementById(divID);
     div.innerHTML = "";
 }
 
@@ -151,14 +150,8 @@ function createPersonOptions() {
 /*----------- Begin Get All Persons -----------*/
 /*---------------------------------------------*/
 
-// TO DELETE WHEN MERGE WITH MASTER - IS COPY OF EXISTING METHOD ON MASTER BRANCH
-function emptyViewPersonWithDataDiv() {
-    let div = document.getElementById("viewPersonWithData");
-    div.innerHTML = "";
-}
-
 function fillViewAllPersonsWithDataDiv() {
-
+    emptyDiv('viewAllPersonsWithDataData');
     let ptag = document.createElement('p');
     ptag.setAttribute('id', 'viewAllPersonsWithDataPTAG');
 
@@ -166,7 +159,7 @@ function fillViewAllPersonsWithDataDiv() {
     buttontag.innerHTML = 'Get All Users';
     buttontag.setAttribute('id', 'viewAllPersonsWithDataTAG');
 
-    let div = document.getElementById("viewPersonWithData");
+    let div = document.getElementById('viewAllPersonsWithDataData');
     div.appendChild(buttontag);
     div.appendChild(ptag);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import 'bootstrap/dist/css/bootstrap.css'
+import { isNullOrUndefined } from 'util';
 document.addEventListener("DOMContentLoaded", function () {
     /*---------- Begin Get Person By Name ---------*/
     /*----- Should be moved to NavBar function ----*/
@@ -87,10 +88,13 @@ function writeToPTagPrPerson(jsondata) {
 
     let stringToWrite =
         "<br>Firstname: " + jsondata['firstName'] + ' ' + jsondata['lastName']
-        + "<br>e-mail: " + jsondata['email']
-        + "<br>Address: " + jsondata['address']['street'] + ', '
-        + jsondata['address']['additionalInfo'] + ', ' + jsondata['address']['cityInfo']['zipCode']
-        + ' ' + jsondata['address']['cityInfo']['city']
+        + "<br>e-mail: " + jsondata['email'];
+    if (!isNullOrUndefined(jsondata['address'])) {
+        stringToWrite = stringToWrite + "<br>Address: " + jsondata['address']['street'] + ', '
+            + jsondata['address']['additionalInfo'] + ', ' + jsondata['address']['cityInfo']['zipCode']
+            + ' ' + jsondata['address']['cityInfo']['city'];
+    }
+    stringToWrite = stringToWrite
         + "<br>Hobbies: " + hobbies
         + "<br>Phones: " + phones;
     return stringToWrite;
@@ -181,28 +185,16 @@ function allUsers() {
 
             jsondata.forEach(element => {
                 allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(element);
-                console.warn("WRITETOPTAG " + writeToPTagPrPerson(element));
-                console.warn("ALLPERSONS " + allPersonsToWrite);
             });
-
-            // let allPersonsToWrite = [];
-            // for (let element in jsondata) {
-
-            //     allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(jsondata[element]);
-            //     allPersonsToWrite.push(writeToPTagPrPerson(jsondata[element]));
-            //     console.warn("WRITETOPTAG " + writeToPTagPrPerson(jsondata[element]));
-            //     console.warn("ALLPERSONS " + allPersonsToWrite);
-            // }
 
             console.warn("ALLPERSONS " + allPersonsToWrite);
 
             document.getElementById('viewAllPersonsWithDataPTAG').innerHTML = allPersonsToWrite;
-            // document.getElementById('viewAllPersonsWithDataPTAG').innerHTML = allPersonsToWrite.join();
         })
         .catch(err => {
             if (err.status) {
                 err.fullError.then(e => console.log(e.detail))
             }
-            else { console.log("Network error"); }
+            else { console.log("Network error: " + err); }
         });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -210,6 +210,7 @@ function allUsersToTableTag() {
             let headdata = Object.keys(jsondata[0]);
             tableHead(table, headdata);
             tableData(table, jsondata);
+            fixTableHeaders();
 
         })
         .catch(err => {
@@ -241,45 +242,45 @@ function tableData(table, bodyData) {
         tbody.appendChild(row);
         for (let key in element) {
             let cell = row.insertCell();
+            let obj = JSON.parse(JSON.stringify(element));
             let cellValue = '';
             if (typeof element[key] === 'object') {
-                let innerelement = element[key];
-                for(let innervalue in innerelement){
-                    if (typeof innerelement[innervalue] === 'object') {
-                        let innerInnerElement = innerelement[innervalue];
-                        for(let innerInnerValue in innerInnerElement){
-                            cellValue += innerInnerElement[innerInnerValue];            
-                        }
-
-                    } else {
-                        cellValue += innerelement[innervalue];
-                    }
+                if(key === 'address'){
+                    cellValue = obj.address.street + ', ' + obj.address.cityInfo.zipCode + ' ' + obj.address.cityInfo.city;
+                }
+                else if(key === 'hobbies'){
+                    obj.hobbies.forEach(hobby => {
+                        cellValue = cellValue + hobby.name + ', ';
+                    });
+                    cellValue = cellValue.slice(0, -2);
+                }
+                else if(key === 'phones'){
+                    obj.phones.forEach(phone => {
+                        cellValue = cellValue + phone.description + ': ' + phone.number + ', ';
+                    });
+                    cellValue = cellValue.slice(0, -2);
                 }
             }
             else {
-                cellValue += element[key];
+                cellValue = element[key];
             }
             let text = document.createTextNode(cellValue);
             cell.appendChild(text);
         }
-        // for (let key in element) {
-        //     let cell = row.insertCell();
-        //     let cellValue;
-        //     if (typeof element[key] === 'object') {
-
-        //           cellValue = 'hell!';  
-        //         // element[key].forEach(element => {
-        //         //     cellValue = cellValue + element[key][element];
-        //         // });
-        //     }
-        //     else {
-        //         cellValue = element[key];
-        //     }
-        //     let text = document.createTextNode(cellValue);
-        //     cell.appendChild(text);
-        // }
     }
 }
+
+function fixTableHeaders(){
+    document.getElementById("address").innerText = "Address";
+    document.getElementById("email").innerText = "E-mail";
+    document.getElementById("firstName").innerText = "Firstname";
+    document.getElementById("id").innerText = "ID";
+    document.getElementById("lastName").innerText = "Lastname";
+    document.getElementById("phones").innerText = "Phone numbers";
+    document.getElementById("hobbies").innerText = "Hobbies";
+    
+}
+
 /*---------------------------------------------*/
 /*------------ End Get All Persons ------------*/
 /*---------------------------------------------*/

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", function () {
     /*---------- Begin Get Person By Name ---------*/
     /*----- Should be moved to NavBar function ----*/
     fillViewPersonWithDataDiv();
-    fillViewAllPersonsWithDataDiv()
+    fillViewAllPersonsWithDataDiv();
     document.getElementById("viewPersonWithDataButtonTAG").addEventListener('click', function (event) {
         event.preventDefault();
         singleuser();
@@ -206,10 +206,11 @@ function allUsersToTableTag() {
     fetch(urlAll)
         .then(handleHttpErrors)
         .then(jsondata => {
+            let sortedData = sortPersonJSON(jsondata);
             let table = document.getElementById('viewAllPersonsWithDataTableTAG');
-            let headdata = Object.keys(jsondata[0]);
+            let headdata = Object.keys(sortedData[0]);
             tableHead(table, headdata);
-            tableData(table, jsondata);
+            tableData(table, sortedData);
             fixTableHeaders();
 
         })
@@ -311,9 +312,9 @@ function sortPersonJSON(persons) {
             firstName: person.firstName,
             lastName: person.lastName,
             email: person.email,
+            address: person.address,
             hobbies: person.hobbies,
             phones: person.phones,
-            address: person.address,
         };
         // Add sorted person to return array
         returnPersons.push(returnPerson);

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ function singleuser() {
         fetch(urlName)
             .then(handleHttpErrors)
             .then(fetchedData => {
-                writeToPTagPrPerson(fetchedData, 'viewPersonWithDataPTAG');
+                document.getElementById('viewPersonWithDataPTAG').innerHTML = writeToPTagPrPerson(fetchedData[0]);
             })
             .catch(err => {
                 if (err.status) {
@@ -75,25 +75,25 @@ function singleuser() {
     }
 }
 
-function writeToPTagPrPerson(jsondata, tagToWrite) {
-    let person = jsondata[0];
+function writeToPTagPrPerson(jsondata) {
     let hobbies = '';
-    person['hobbies'].forEach(element => {
+    jsondata['hobbies'].forEach(element => {
         hobbies = hobbies + '<br>' + element.name + ' - ' + element.description;
     });
     let phones = '';
-    person['phones'].forEach(element => {
+    jsondata['phones'].forEach(element => {
         phones = phones + '<br>' + element.description + ': ' + element.number;
     });
 
-    document.getElementById(tagToWrite).innerHTML =
-        "<br>Firstname: " + person['firstName'] + ' ' + person['lastName']
-        + "<br>e-mail: " + person['email']
-        + "<br>Address: " + person['address']['street'] + ', '
-        + person['address']['additionalInfo'] + ', ' + person['address']['cityInfo']['zipCode']
-        + ' ' + person['address']['cityInfo']['city']
+    let stringToWrite =
+        "<br>Firstname: " + jsondata['firstName'] + ' ' + jsondata['lastName']
+        + "<br>e-mail: " + jsondata['email']
+        + "<br>Address: " + jsondata['address']['street'] + ', '
+        + jsondata['address']['additionalInfo'] + ', ' + jsondata['address']['cityInfo']['zipCode']
+        + ' ' + jsondata['address']['cityInfo']['city']
         + "<br>Hobbies: " + hobbies
         + "<br>Phones: " + phones;
+    return stringToWrite;
 }
 
 /*---------------------------------------------*/
@@ -176,9 +176,16 @@ function allUsers() {
     fetch(urlAll)
         .then(handleHttpErrors)
         .then(jsondata => {
-            jsondata.forEach(element => {
-                writeToPTagPrPerson(element, 'viewAllPersonsWithDataPTAG');
-            });
+
+            let allPersonsToWrite = '';
+            for (let element in jsondata) {
+                allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(jsondata[element]);
+                // console.warn("WRITETOPTAG " + writeToPTagPrPerson(jsondata[element]));
+                // console.warn("ALLPERSONS " + allPersonsToWrite);
+            }
+
+            console.warn("ALLPERSONS " + allPersonsToWrite);
+            document.getElementById('viewAllPersonsWithDataPTAG').innerHTML = allPersonsToWrite;
         })
         .catch(err => {
             if (err.status) {

--- a/src/index.js
+++ b/src/index.js
@@ -186,9 +186,6 @@ function allUsersToPtag() {
             jsondata.forEach(element => {
                 allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(element);
             });
-
-            console.warn("ALLPERSONS " + allPersonsToWrite);
-
             document.getElementById('viewAllPersonsWithDataPTAG').innerHTML = allPersonsToWrite;
         })
         .catch(err => {
@@ -198,3 +195,7 @@ function allUsersToPtag() {
             else { console.log("Network error: " + err); }
         });
 }
+
+/*---------------------------------------------*/
+/*------------ End Get All Persons ------------*/
+/*---------------------------------------------*/

--- a/src/index.js
+++ b/src/index.js
@@ -178,14 +178,26 @@ function allUsers() {
         .then(jsondata => {
 
             let allPersonsToWrite = '';
-            for (let element in jsondata) {
-                allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(jsondata[element]);
-                // console.warn("WRITETOPTAG " + writeToPTagPrPerson(jsondata[element]));
-                // console.warn("ALLPERSONS " + allPersonsToWrite);
-            }
+
+            jsondata.forEach(element => {
+                allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(element);
+                console.warn("WRITETOPTAG " + writeToPTagPrPerson(element));
+                console.warn("ALLPERSONS " + allPersonsToWrite);
+            });
+
+            // let allPersonsToWrite = [];
+            // for (let element in jsondata) {
+
+            //     allPersonsToWrite = allPersonsToWrite + writeToPTagPrPerson(jsondata[element]);
+            //     allPersonsToWrite.push(writeToPTagPrPerson(jsondata[element]));
+            //     console.warn("WRITETOPTAG " + writeToPTagPrPerson(jsondata[element]));
+            //     console.warn("ALLPERSONS " + allPersonsToWrite);
+            // }
 
             console.warn("ALLPERSONS " + allPersonsToWrite);
+
             document.getElementById('viewAllPersonsWithDataPTAG').innerHTML = allPersonsToWrite;
+            // document.getElementById('viewAllPersonsWithDataPTAG').innerHTML = allPersonsToWrite.join();
         })
         .catch(err => {
             if (err.status) {
@@ -193,5 +205,4 @@ function allUsers() {
             }
             else { console.log("Network error"); }
         });
-
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     document.getElementById("viewAllPersonsWithDataButtonTAG").addEventListener('click', function (event) {
         event.preventDefault();
-        allUsers();
+        allUsersToPtag();
     });
 });
 
@@ -175,7 +175,7 @@ function fillViewAllPersonsWithDataDiv() {
     div.appendChild(ptag);
 }
 
-function allUsers() {
+function allUsersToPtag() {
     let urlAll = url + 'allpersons';
     fetch(urlAll)
         .then(handleHttpErrors)

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
     document.getElementById("viewAllPersonsWithDataButtonTAG").addEventListener('click', function (event) {
         event.preventDefault();
         allUsersToPtag();
+        allUsersToTableTag();
     });
 });
 
@@ -200,6 +201,85 @@ function allUsersToPtag() {
         });
 }
 
+function allUsersToTableTag() {
+    let urlAll = url + 'allpersons';
+    fetch(urlAll)
+        .then(handleHttpErrors)
+        .then(jsondata => {
+            let table = document.getElementById('viewAllPersonsWithDataTableTAG');
+            let headdata = Object.keys(jsondata[0]);
+            tableHead(table, headdata);
+            tableData(table, jsondata);
+
+        })
+        .catch(err => {
+            if (err.status) {
+                err.fullError.then(e => console.log(e.detail))
+            }
+            else { console.log("Network error: " + err); }
+        });
+}
+
+function tableHead(table, headData) {
+    let head = table.createTHead();
+    let row = head.insertRow();
+    for (let key of headData) {
+        let th = document.createElement("th");
+        let text = document.createTextNode(key);
+        th.id = key;
+        th.appendChild(text);
+        row.appendChild(th);
+    }
+
+}
+
+function tableData(table, bodyData) {
+    let tbody = document.createElement('tbody');
+    table.appendChild(tbody);
+    for (let element of bodyData) {
+        let row = table.insertRow();
+        tbody.appendChild(row);
+        for (let key in element) {
+            let cell = row.insertCell();
+            let cellValue = '';
+            if (typeof element[key] === 'object') {
+                let innerelement = element[key];
+                for(let innervalue in innerelement){
+                    if (typeof innerelement[innervalue] === 'object') {
+                        let innerInnerElement = innerelement[innervalue];
+                        for(let innerInnerValue in innerInnerElement){
+                            cellValue += innerInnerElement[innerInnerValue];            
+                        }
+
+                    } else {
+                        cellValue += innerelement[innervalue];
+                    }
+                }
+            }
+            else {
+                cellValue += element[key];
+            }
+            let text = document.createTextNode(cellValue);
+            cell.appendChild(text);
+        }
+        // for (let key in element) {
+        //     let cell = row.insertCell();
+        //     let cellValue;
+        //     if (typeof element[key] === 'object') {
+
+        //           cellValue = 'hell!';  
+        //         // element[key].forEach(element => {
+        //         //     cellValue = cellValue + element[key][element];
+        //         // });
+        //     }
+        //     else {
+        //         cellValue = element[key];
+        //     }
+        //     let text = document.createTextNode(cellValue);
+        //     cell.appendChild(text);
+        // }
+    }
+}
 /*---------------------------------------------*/
 /*------------ End Get All Persons ------------*/
 /*---------------------------------------------*/

--- a/src/index.js
+++ b/src/index.js
@@ -18,41 +18,41 @@ var output = document.getElementById("output");
 
 var buttonAddSimple = document.getElementById("createSimplePerson");
 
-buttonAddSimple.addEventListener("click", function(){
+buttonAddSimple.addEventListener("click", function () {
     fetch(url + "create/person", createPersonOptions())
-    .then(res => handleHttpErrors(res))
-    .then(function(data) {
-        console.log(data);
-        output.innerHTML = "<p>Person created:</p><br>"
-        + "<p>ID: " + data.id + "<br>"
-        + "<p>First name: " + data.firstName + "<br>"
-        + "<p>Last name: " + data.lastName + "<br>"
-        + "<p>email: " + data.email + "<br>";
-    })
-    .catch(err => {
-        if(err.status){
-          err.fullError.then(e => output.innerHTML = "Error:<br><br>")
-        }
-        else{console.log("Network error"); }
-     });
+        .then(res => handleHttpErrors(res))
+        .then(function (data) {
+            console.log(data);
+            output.innerHTML = "<p>Person created:</p><br>"
+                + "<p>ID: " + data.id + "<br>"
+                + "<p>First name: " + data.firstName + "<br>"
+                + "<p>Last name: " + data.lastName + "<br>"
+                + "<p>email: " + data.email + "<br>";
+        })
+        .catch(err => {
+            if (err.status) {
+                err.fullError.then(e => output.innerHTML = "Error:<br><br>")
+            }
+            else { console.log("Network error"); }
+        });
 })
 
-function createPersonOptions(){
+function createPersonOptions() {
     var FirstName = document.getElementById("inputFirstName").value;
     var LastName = document.getElementById("inputLastName").value;
     var Email = document.getElementById("inputEmail").value;
     var Method = "POST";
     var data = {
-        firstName : FirstName,
-        lastName : LastName,
-        email : Email
+        firstName: FirstName,
+        lastName: LastName,
+        email: Email
     }
-    
+
     let options = {
         method: Method,
         headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
         },
         body: JSON.stringify(data)
     }
@@ -64,3 +64,59 @@ function createPersonOptions(){
 /*----------- End Add Person Simple -----------*/
 /*---------------------------------------------*/
 
+/*---------------------------------------------*/
+/*----------- Begin Get All Persons -----------*/
+/*---------------------------------------------*/
+
+// TO DELETE WHEN MERGE WITH MASTER - IS CPOPY OF EXISTING METHOD ON MASTER BRANCH
+function emptyViewPersonWithDataDiv() {
+    let div = document.getElementById("viewPersonWithData");
+    div.innerHTML = "";
+}
+
+function fillViewAllPersonsWithDataDiv() {
+
+    let ptag = document.createElement('p');
+    ptag.setAttribute('id', 'viewAllPersonsWithDataPTAG');
+
+    let buttontag = document.createElement('button');
+    buttontag.innerHTML = 'Get All Users';
+    buttontag.setAttribute('id', 'viewAllPersonsWithDataTAG');
+
+    let div = document.getElementById("viewPersonWithData");
+    div.appendChild(buttontag);
+    div.appendChild(ptag);
+}
+
+function allUsers() {
+    let urlAll = url + '/allpersons';
+    fetch(urlAll)
+        .then(handleHttpErrors)
+        .then(jsondata => {
+            let person = jsondata[0];
+            let hobbies = '';
+            person['hobbies'].forEach(element => {
+                hobbies = hobbies + '<br>' + element.name + ' - ' + element.description;
+            });
+            let phones = '';
+            person['phones'].forEach(element => {
+                phones = phones + '<br>' + element.description + ': ' + element.number;
+            });
+
+            document.getElementById('viewPersonWithDataPTAG').innerHTML =
+                "<br>Firstname: " + person['firstName'] + ' ' + person['lastName']
+                + "<br>e-mail: " + person['email']
+                + "<br>Address: " + person['address']['street'] + ', '
+                + person['address']['additionalInfo'] + ', ' + person['address']['cityInfo']['zipCode']
+                + ' ' + person['address']['cityInfo']['city']
+                + "<br>Hobbies: " + hobbies
+                + "<br>Phones: " + phones;
+        })
+        .catch(err => {
+            if (err.status) {
+                err.fullError.then(e => console.log(e.detail))
+            }
+            else { console.log("Network error"); }
+        });
+
+}


### PR DESCRIPTION
Fixes #20
The functionality for showing all users in both a table and a p-tag is ready for implementation. The table is not full-on automated as we first discussed, since the code ended up being unreadable because of all the inner objects each object has. 

This should still be able to make use of the sort function when that is implemented. 

Table looks like this now (no styling):
![image](https://user-images.githubusercontent.com/35559774/66909137-87cacf00-f00c-11e9-8468-5fe8b6d4be3e.png)


The p-tag looks like this (also no styling):

![image](https://user-images.githubusercontent.com/35559774/66909222-a8932480-f00c-11e9-95e6-f4907875c1ea.png)

